### PR TITLE
Fixes error "Template directory should be relative to skin or omitted"

### DIFF
--- a/skins/Openemr/skin.json
+++ b/skins/Openemr/skin.json
@@ -7,7 +7,6 @@
 			"args": [ {
 				"name": "openemr",
 				"responsive": true,
-				"templateDirectory": "skins/Openemr/templates",
 				"styles": [
 					"skins.openemr"
 				],


### PR DESCRIPTION
As of 1.37 the template directory can be omitted - it defaults to templates
folder in the skin

If you need to support 1.36, you'll want to hold off merging this patch until you are ready.